### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -23,13 +23,13 @@ jobs:
         uses: actions/checkout@v2
         if: github.event.pull_request == null
         with:
-          path: Starbound-ZakuroHatMod
+          path: CrimicCosmos
 
       - name: Checkout (Pull request)
         uses: actions/checkout@v2
         if: github.event.pull_request != null
         with:
-          path: Starbound-ZakuroHatMod
+          path: CrimicCosmos
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout damianb/sbpak
@@ -47,14 +47,14 @@ jobs:
       - name: Get metadata
         id: metadata
         run: |
-          NAME=`cat Starbound-ZakuroHatMod/_metadata | jq -r .name`
-          VERSION=`cat Starbound-ZakuroHatMod/_metadata | jq -r .version`
-          echo "::set-output name=NAME::${NAME}"
-          echo "::set-output name=VERSION::${VERSION}"
-          echo "::set-output name=FILENAME::${NAME}-${VERSION}.pak"
+          NAME=`cat CrimicCosmos/_metadata | jq -r .name`
+          VERSION=`cat CrimicCosmos/_metadata | jq -r .version`
+          echo "NAME=${NAME}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "FILENAME=${NAME}-${VERSION}.pak" >> $GITHUB_OUTPUT
 
       - name: Pack
-        run: npx sbpak pack Starbound-ZakuroHatMod ${{ steps.metadata.outputs.FILENAME }}
+        run: npx sbpak pack CrimicCosmos ${{ steps.metadata.outputs.FILENAME }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,41 +16,41 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
 
       - uses: actions/checkout@v2
         with:
-          path: Starbound-ZakuroHatMod
+          path: CrimicCosmos
 
       - uses: actions/checkout@v2
         with:
-          path: Starbound-ZakuroHatMod-main
+          path: CrimicCosmos-main
           ref: main
           fetch-depth: 0
 
       - name: Reset latest merge
         run: |
-          cd Starbound-ZakuroHatMod-main
+          cd CrimicCosmos-main
           git reset --hard HEAD~1
           cd ..
 
       - name: Get main metadata
         id: mainMetadata
         run: |
-          NAME=`cat Starbound-ZakuroHatMod-main/_metadata | jq -r .name`
-          VERSION=`cat Starbound-ZakuroHatMod-main/_metadata | jq -r .version`
-          echo "::set-output name=NAME::${NAME}"
-          echo "::set-output name=VERSION::${VERSION}"
+          NAME=`cat CrimicCosmos-main/_metadata | jq -r .name`
+          VERSION=`cat CrimicCosmos-main/_metadata | jq -r .version`
+          echo "NAME=${NAME}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "VERSION: ${VERSION}"
 
       - name: Get current metadata
         id: metadata
         run: |
-          NAME=`cat Starbound-ZakuroHatMod/_metadata | jq -r .name`
-          VERSION=`cat Starbound-ZakuroHatMod/_metadata | jq -r .version`
-          echo "::set-output name=NAME::${NAME}"
-          echo "::set-output name=VERSION::${VERSION}"
-          echo "::set-output name=FILENAME::${NAME}-${VERSION}.pak"
+          NAME=`cat CrimicCosmos/_metadata | jq -r .name`
+          VERSION=`cat CrimicCosmos/_metadata | jq -r .version`
+          echo "NAME=${NAME}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "FILENAME=${NAME}-${VERSION}.pak" >> $GITHUB_OUTPUT
           echo "VERSION: ${VERSION}"
 
       - uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
 
       - name: Pack
         if: ${{ steps.mainMetadata.outputs.VERSION != steps.metadata.outputs.VERSION }}
-        run: npx sbpak pack Starbound-ZakuroHatMod ${{ steps.metadata.outputs.FILENAME }}
+        run: npx sbpak pack CrimicCosmos ${{ steps.metadata.outputs.FILENAME }}
 
       - name: Create a Release
         if: ${{ steps.mainMetadata.outputs.VERSION != steps.metadata.outputs.VERSION }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

上記記事に関するCI修正と、CI内で放置されていた `Starbound-ZakuroHatMod` 文字列を `CrimicCosmos` に置き換えました。
CIのみの変更のため、バージョン更新はありません。