### PR TITLE
fix(ci): pull_request_target による脆弱性に対応

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -63,7 +63,7 @@ jobs:
         run: npx sbpak pack CrimicCosmos ${{ steps.metadata.outputs.FILENAME }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.metadata.outputs.FILENAME }}
           path: ${{ steps.metadata.outputs.FILENAME }}

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: CrimicCosmos
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -19,10 +19,20 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: 承認リクエストコメントを投稿
-        uses: peter-evans/create-or-update-comment@v4
+      - name: 既存の承認リクエストコメントを検索
+        id: find-comment
+        uses: peter-evans/find-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: Environment 承認待ち
+
+      - name: 承認リクエストコメントを投稿または更新
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
           body: |
             ## Environment 承認待ち
 
@@ -37,6 +47,9 @@ jobs:
     if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')
     # pull_request_target イベントの場合は Environment で手動承認が必要（フォーク PR を含む外部コードの安全な実行のため）
     environment: ${{ github.event_name == 'pull_request_target' && 'pr-preview' || null }}
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Setup node

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -35,7 +35,7 @@ jobs:
     needs: post-approval-request
     # post-approval-request が skipped（push イベント）または success（pull_request_target）のときのみ実行する
     if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')
-    # pull_request_target（フォーク PR）の場合は Environment で手動承認が必要
+    # pull_request_target イベントの場合は Environment で手動承認が必要（フォーク PR を含む外部コードの安全な実行のため）
     environment: ${{ github.event_name == 'pull_request_target' && 'pr-preview' || null }}
 
     steps:

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   post-approval-request:
     runs-on: ubuntu-latest
-    # pull_request_target イベントのときのみ承認リクエストを投稿する
-    if: github.event_name == 'pull_request_target'
+    # フォーク PR のときのみ承認リクエストを投稿する（同一リポジトリからの PR は不要）
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     permissions:
       pull-requests: write
     steps:
@@ -45,8 +45,8 @@ jobs:
     needs: post-approval-request
     # post-approval-request が skipped（push イベント）または success（pull_request_target）のときのみ実行する
     if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')
-    # pull_request_target イベントの場合は Environment で手動承認が必要（フォーク PR を含む外部コードの安全な実行のため）
-    environment: ${{ github.event_name == 'pull_request_target' && 'pr-preview' || null }}
+    # フォーク PR の場合のみ Environment で手動承認が必要（同一リポジトリからの PR は不要）
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'pr-preview' || null }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -12,8 +12,31 @@ on:
       - synchronize
 
 jobs:
+  post-approval-request:
+    runs-on: ubuntu-latest
+    # pull_request_target イベントのときのみ承認リクエストを投稿する
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: 承認リクエストコメントを投稿
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Environment 承認待ち
+
+            この PR のビルドを実行するには、Environment `pr-preview` の承認が必要です。
+
+            [Actions run を確認して承認してください](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
+
   pack:
     runs-on: ubuntu-latest
+    needs: post-approval-request
+    # post-approval-request が skipped（push イベント）または success（pull_request_target）のときのみ実行する
+    if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')
+    # pull_request_target（フォーク PR）の場合は Environment で手動承認が必要
+    environment: ${{ github.event_name == 'pull_request_target' && 'pr-preview' || null }}
 
     steps:
       - name: Setup node

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: 既存の承認リクエストコメントを検索
+      - name: Find existing approval request comment
         id: find-comment
         uses: peter-evans/find-comment@v3
         with:
@@ -27,7 +27,7 @@ jobs:
           comment-author: github-actions[bot]
           body-includes: Environment 承認待ち
 
-      - name: 承認リクエストコメントを投稿または更新
+      - name: Post or update approval request comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -36,7 +36,7 @@ jobs:
           body: |
             ## Environment 承認待ち
 
-            この PR のビルドを実行するには、Environment `pr-preview` の承認が必要です。
+            この PR のビルドを実行するには、Environment `fork-pr-build` の承認が必要です。
 
             [Actions run を確認して承認してください](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
 
@@ -46,7 +46,7 @@ jobs:
     # post-approval-request が skipped（push イベント）または success（pull_request_target）のときのみ実行する
     if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')
     # フォーク PR の場合のみ Environment で手動承認が必要（同一リポジトリからの PR は不要）
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'pr-preview' || null }}
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-build' || null }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## 概要

`pack.yml` において `pull_request_target` トリガーでフォーク PR のコードをチェックアウト後に実行する処理が `GITHUB_TOKEN`（書き込み権限）にアクセスできる状態だった脆弱性を修正します。

## 脆弱性の内容

```yaml
on: pull_request_target  # ← ベースリポジトリのコンテキスト（secrets 使用可能）

- uses: actions/checkout@v3
  with:
    ref: ${{ github.event.pull_request.head.sha || github.sha }}  # ← フォーク PR のコードを取得

- run: npx sbpak pack CrimicCosmos ...  # ← フォーク PR の悪意あるコードが実行される
```

フォーク PR の攻撃者が `package.json` の `postinstall` 等に悪意あるコードを仕込むことで、書き込み権限を持つ `GITHUB_TOKEN` を窃取できる状態でした。

## 変更内容

`book000/sync-repo-settings` の `pr-preview.yml` と同様のパターンを採用しました。

### 追加: `post-approval-request` ジョブ

**フォーク PR のみ**（`head.repo.full_name != github.repository`）実行し、PR に承認待ちコメントを投稿します。`peter-evans/find-comment` で既存コメントを検索し更新することで、synchronize ごとにコメントが重複しないよう対応しています。

### 変更: `pack` ジョブ

- `needs: post-approval-request` を追加
- `if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')` で push イベントや同一リポジトリ PR（skipped）時も動作するよう対応
- `environment` を**フォーク PR のみ** `fork-pr-build` に設定（同一リポジトリからの PR は承認不要）
- `permissions: contents: read, pull-requests: write` を明示追加し GITHUB_TOKEN の最小権限化

### その他

- `actions/upload-artifact` を v3（廃止済み）から v4 に更新
- `actions/setup-node` / `actions/checkout` を v3（Node16 ベース）から v4（Node20 ベース）に更新
- 各ステップの name を英語に統一

## 動作フロー

```
[push to main]
  → pack ジョブが直接実行（承認不要）

[同一リポジトリからの PR]
  → pack ジョブが直接実行（承認不要）

[フォーク PR オープン/更新]
  → post-approval-request: 承認待ちコメントを投稿または更新
  → pack: Environment `fork-pr-build` の承認待ちでブロック
  → 承認後: フォーク PR のコードをチェックアウトしてビルド実行
```

## ⚠️ マージ前に必要な設定

本変更を有効にするには、リポジトリ Settings で `fork-pr-build` Environment を作成し、**Required reviewers** を設定してください。

> **[→ Environment `fork-pr-build` を今すぐ作成する](https://github.com/jaoafa/CrimicCosmos/settings/environments/new)**
>
> 1. 上のリンクを開く
> 2. Name に `fork-pr-build` と入力して「Configure environment」をクリック
> 3. `Required reviewers` にレビュアーを追加
> 4. `Save protection rules` をクリック

> [!NOTE]
> GitHub の Environment 作成ページは URL パラメータによる Name の事前入力に対応していないため、手動での入力が必要です。