### PR TITLE
fix(ci): environment: 式の || null を || '' に変更して startup_failure を修正

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -46,7 +46,7 @@ jobs:
     # post-approval-request が skipped（push イベント）または success（pull_request_target）のときのみ実行する
     if: always() && (needs.post-approval-request.result == 'success' || needs.post-approval-request.result == 'skipped')
     # フォーク PR の場合のみ Environment で手動承認が必要（同一リポジトリからの PR は不要）
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-build' || null }}
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-build' || '' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

`.github/workflows/pack.yml` の `environment:` フィールドで `|| null` を使用しており、GitHub Actions の起動時バリデーションで `startup_failure` が発生する可能性がありました。`|| null` を `|| ''` に変更することで修正しました。

## 変更内容

### `pack.yml` の `environment:` 式を修正

**修正前:**
```yaml
environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-build' || null }}
```

**修正後:**
```yaml
environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-build' || '' }}
```

GitHub Actions は `environment:` フィールドに `null` を受け取ると、ワークフロー起動時のバリデーションで `startup_failure` を発生させます。空文字列 `''` を使用することで、フォーク PR 以外のケースでは Environment が設定されず、正常に動作します。

## 参考

- Issue #50

- Closes #50